### PR TITLE
fix: remove incorrect CORE_AREA test assertion

### DIFF
--- a/sram_forge/tests/test_generate_librelane.py
+++ b/sram_forge/tests/test_generate_librelane.py
@@ -63,9 +63,8 @@ def test_generate_config_yaml(librelane_engine, chip_config, sram_spec, slot_spe
     # Should be valid YAML-like content
     assert "DESIGN_NAME" in result or "design_name" in result.lower()
 
-    # Should have die and core areas
+    # Should have die area reference (used in logo positioning)
     assert "DIE_AREA" in result or "die_area" in result.lower()
-    assert "CORE_AREA" in result or "core_area" in result.lower()
 
     # Should reference SRAM macros
     assert "MACRO" in result.upper() or "macro" in result.lower()


### PR DESCRIPTION
## Summary
- Remove incorrect `CORE_AREA` assertion from `test_generate_config_yaml`
- The LibreLane config template doesn't use `CORE_AREA` (only `DIE_AREA` for logo positioning)
- This fixes the CI failure on main caused by the template alignment in commit 65b5952

## Test plan
- [x] All 73 tests pass locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions for improved validation clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->